### PR TITLE
Fixed dropbox component class 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ return [
 Install dependency 
 
 ```bash
-$ composer require league/flysystem-dropbox
+$ composer require spatie/flysystem-dropbox
 ```
 
 Configure on the application `components` section:
@@ -138,8 +138,7 @@ return [
         //...
         'fs' => [
             'class' => 'dosamigos\flysystem\DropboxFsComponent',
-            'token' => 'your-token',
-            'app' => 'your-app',
+            'token' => 'your-access-token',
             // 'prefix' => 'your-prefix',
         ],
     ],

--- a/src/DropboxFsComponent.php
+++ b/src/DropboxFsComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of the 2amigos/yii2-flysystem-component project.
  *
@@ -7,6 +8,7 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
+
 namespace dosamigos\flysystem;
 
 use Spatie\Dropbox\Client;
@@ -15,18 +17,16 @@ use yii\base\InvalidConfigException;
 
 class DropboxFsComponent extends AbstractFsComponent
 {
+
     /**
      * @var string
      */
     public $token;
+
     /**
      * @var string
      */
-    public $app;
-    /**
-     * @var string|null
-     */
-    public $prefix;
+    public $prefix = '';
 
     /**
      * @inheritdoc
@@ -37,8 +37,8 @@ class DropboxFsComponent extends AbstractFsComponent
             throw new InvalidConfigException('The "token" property must be set.');
         }
 
-        if ($this->app === null) {
-            throw new InvalidConfigException('The "app" property must be set.');
+        if (!is_string($this->prefix)) {
+            throw new InvalidConfigException('The "prefix" property must be a string.');
         }
 
         parent::init();
@@ -50,8 +50,8 @@ class DropboxFsComponent extends AbstractFsComponent
     protected function initAdapter()
     {
         return new DropboxAdapter(
-            new Client($this->token, $this->app),
-            $this->prefix
+            new Client($this->token), $this->prefix
         );
     }
+
 }

--- a/src/DropboxFsComponent.php
+++ b/src/DropboxFsComponent.php
@@ -17,7 +17,6 @@ use yii\base\InvalidConfigException;
 
 class DropboxFsComponent extends AbstractFsComponent
 {
-
     /**
      * @var string
      */
@@ -53,5 +52,4 @@ class DropboxFsComponent extends AbstractFsComponent
             new Client($this->token), $this->prefix
         );
     }
-
 }


### PR DESCRIPTION
+ Updated `initAdapter` method so it matches `Spatie\Dropbox\Client` constructor signature
+ Updated README.md

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #2 

Be aware that `Spatie\Dropbox\Client` is PHP 7 only.