### PR TITLE
Invoke parent::__call on AbstractFsComponent 

### DIFF
--- a/src/AbstractFsComponent.php
+++ b/src/AbstractFsComponent.php
@@ -87,7 +87,11 @@ abstract class AbstractFsComponent extends Component
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->filesystem, $method], $parameters);
+        if (method_exists($this->filesystem, $method)) {
+            return call_user_func_array([$this->filesystem, $method], $parameters);
+        }
+
+        return parent::__call($method, $parameters);
     }
 
     /**


### PR DESCRIPTION
Call parent::__call on AbstractFsComponent to invoke attached behaviours' methods

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
