### PR TITLE
Fix for league sftp adapter >= 1.0.19

### DIFF
--- a/src/SftpFsComponent.php
+++ b/src/SftpFsComponent.php
@@ -87,7 +87,7 @@ class SftpFsComponent extends AbstractFsComponent
                 'root' => $this->root,
                 'permPrivate' => $this->permPrivate,
                 'permPublic' => $this->permPublic,
-                'privatekey' => $this->privateKey
+                'privateKey' => $this->privateKey
             ]
         );
 


### PR DESCRIPTION
league sftp adapter changed the privatekey prop in privateKey as of 1.0.19 version

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

